### PR TITLE
Update dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - python
   - pip
   - astroplan
-  - astropy<6 # see https://github.com/gammapy/gammapy/issues/4972
+  - astropy<7
   - gammapy
   - seaborn
   - scipy=1.11* # see https://github.com/gammapy/gammapy/pull/4997

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - pip
   - astroplan
   - astropy<7
+  - matplotlib<3.10
   - gammapy
   - seaborn
   - scipy=1.11* # see https://github.com/gammapy/gammapy/pull/4997

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 dependencies = [
     "astroplan",
     "astropy<7",
+    "matplotlib<3.10",
     "gammapy",
     "seaborn",
     "scipy<1.12", # see https://github.com/gammapy/gammapy/pull/4997

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "astroplan",
-    "astropy<6",  # see https://github.com/gammapy/gammapy/issues/4972
+    "astropy<7",
     "gammapy",
     "seaborn",
     "scipy<1.12", # see https://github.com/gammapy/gammapy/pull/4997


### PR DESCRIPTION
- _gammapy_ now works with _astropy_ v6
- _matplotlib_ 3.10 removed `mpl_toolkits.axes_grid1.anchored_artists.AnchoredEllipse` which _gammapy_ still needs

the latter should be the reason why #35 and #36 tests fail with pip (conda package for 3.10 is not yet available so that pipe succeeds)