### PR TITLE
Remove core dependencies constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,10 @@ classifiers = [
 ]
 dependencies = [
     "astroplan",
-    "astropy<7",
-    "matplotlib<3.10",
+    "astropy",
+    "matplotlib",
     "gammapy",
     "seaborn",
-    "scipy<1.12", # see https://github.com/gammapy/gammapy/pull/4997
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Some time has passed since I touched this project, meanwhile the constraint gammapy had on scipy has been lifted (see gammapy/gammapy#4997) and the other constraints did not make sense also because soon we will drop python 3.9 anyway.